### PR TITLE
Added libunwind8 for dotnet 2.2.4

### DIFF
--- a/BuildDotNetCore.sh
+++ b/BuildDotNetCore.sh
@@ -31,8 +31,9 @@ BuildClr()
 	echo "Press enter when done"
 	read Uninstalled
 
+	sudo apt-get install libunwind8
 	sudo apt-get install debootstrap
-	sudo apt-get install qemu-user-static libunwind8
+	sudo apt-get install qemu-user-static
 	cd coreclr
 	sudo ./cross/build-rootfs.sh x86
 	sudo apt-get install cmake

--- a/BuildDotNetCore.sh
+++ b/BuildDotNetCore.sh
@@ -32,7 +32,7 @@ BuildClr()
 	read Uninstalled
 
 	sudo apt-get install debootstrap
-	sudo apt-get install qemu-user-static
+	sudo apt-get install qemu-user-static libunwind8
 	cd coreclr
 	sudo ./cross/build-rootfs.sh x86
 	sudo apt-get install cmake


### PR DESCRIPTION
Just ran into this while compiling on Debian 9. Had to install the `libunwind8` package to continue building. Also installed `libunwind8-dev` for good measure but it is probably not needed.